### PR TITLE
Update the application for PHP 8 compatibility.

### DIFF
--- a/class/List.php
+++ b/class/List.php
@@ -16,11 +16,11 @@ class BoardList extends Base
   function prep_data($row)
   {
     global $Parse;
-  
+
     $data = array_values($row);
-    
+
     // start shared parsing
-    $data['date'] = date(LIST_DATE_FORMAT,$data[LIST_DATE_LAST_POST]);
+    $data['date'] = date(LIST_DATE_FORMAT,(int)$data[LIST_DATE_LAST_POST]);
     $data['subject'] = htmlentities($data[LIST_SUBJECT],ENT_QUOTES,"UTF-8");
 
     $data['dot'] = $data['fav'] = $data['read'] = $data['me'] = "";

--- a/class/Parse.php
+++ b/class/Parse.php
@@ -109,7 +109,8 @@ class BoardParse
     if(($host == "twitter.com" || $host == "www.twitter.com" || $host == "mobile.twitter.com") && isset($url['path']))
     {
       // The tweet ID is the last part of the path, and it should be numeric.
-      $tweet_id = end(explode('/', $url['path']));
+      $tweet_url_path = explode('/', $url['path']);
+      $tweet_id = end($tweet_url_path);
       if ($tweet_id && is_numeric($tweet_id))
       {
         // Assign this tweet's DOM elements unique IDs to distinguish them from

--- a/class/Parse.php
+++ b/class/Parse.php
@@ -190,12 +190,12 @@ class BoardParse
     }
 
     // start line break stuff
-    $s = str_replace('<br />',NULL,$s);
+    $s = str_replace('<br />','',$s);
     $s = nl2br(chop($s));
-  
+
     // remove line breaks inside these tags
     $lbr = array(array("<pre>","</pre>"));
-  
+
     foreach($lbr as $lb)
     {
       $lb1 = $lb[0];
@@ -211,7 +211,7 @@ class BoardParse
       $s = preg_replace("#".$lb2q."(\r\n)\<br \/\>#i",$lb2,$s);
     }
     // end line break stuff
-  
+
     return $s;
   }
 }

--- a/class/Query.php
+++ b/class/Query.php
@@ -44,10 +44,10 @@ class BoardQuery
   /**
   * build thread listing query
   */
-  function list_thread($sticky=false,$offset,$limit,$threads=false,$cond=false,$ignore_threads=true)
+  function list_thread($offset, $limit, $sticky = false, $threads = false, $cond = false, $ignore_threads = true)
   {
     global $Core;
-    
+
     // set query conditionals
     $where = "WHERE t.sticky IS false";
     $order = "ORDER BY t.date_last_posted DESC";
@@ -126,7 +126,7 @@ class BoardQuery
   function list_thread_bymember($member_id,$offset,$limit)
   {
     $cond = "WHERE t.member_id=$member_id";
-    return $this->list_thread(false,$offset,$limit,array(),$cond);
+    return $this->list_thread($offset, $limit, false, [], $cond);
   }
 
   /**

--- a/class/Query.php
+++ b/class/Query.php
@@ -132,7 +132,7 @@ class BoardQuery
   /**
   * build thread view query
   */
-  function view_thread($thread=false,$offset,$limit,$posts=false,$cond=false)
+  function view_thread($offset, $limit, $thread = false, $posts = false, $cond = false)
   {
     global $Core;
 
@@ -207,7 +207,7 @@ class BoardQuery
   function view_thread_bymember($member_id,$offset,$limit)
   {
     $cond = "WHERE tp.member_id=$member_id";
-    return $this->view_thread(false,$offset,$limit,false,$cond);
+    return $this->view_thread($offset, $limit, false, false, $cond);
   }
 
   /**
@@ -216,7 +216,7 @@ class BoardQuery
   function list_message($offset,$limit,$messages=false)
   {
     global $Core;
-  
+
     // set query conditionals
     $where = "WHERE";
     $order = "ORDER BY m.date_last_posted DESC";

--- a/class/View.php
+++ b/class/View.php
@@ -18,9 +18,9 @@ class BoardView extends Base
   function prep_data($row)
   {
     global $Parse;
-    
+
     $data = array_values($row);
-    $data['date'] = date(VIEW_DATE_FORMAT,$data[VIEW_DATE_POSTED]);
+    $data['date'] = date(VIEW_DATE_FORMAT,(int)$data[VIEW_DATE_POSTED]);
 
     $data['me'] = $data['quote'] = $data['admin'] = "";
     if(session('id'))
@@ -85,7 +85,7 @@ class BoardView extends Base
       if($list = array_keys($Core->list_ignored(session('id')))) $list = implode(",",$list);
       else
       $list = "0";
-      
+
       // minimum number of posts before collapse
       $mincollapse = is_numeric(session('mincollapse')) ? session('mincollapse') : COLLAPSE_DEFAULT;
 
@@ -95,7 +95,7 @@ class BoardView extends Base
 
       // offset collapsing by the number of people ignored
       $offsetignores = $DB->value("SELECT count(*) FROM {$this->table}_post WHERE {$this->table}_id=$1 AND member_id IN ($list)",array(id()));
-      
+
       $this->collapse($DB->value("SELECT COALESCE(last_view_posts,0)-$offsetignores-$collapseopen FROM {$this->table}_member WHERE {$this->table}_id=$1 AND member_id=$2",array(id(),session('id'))));
 
       // don't collapse if there aren't new posts or if we are offsetting/limiting
@@ -164,14 +164,14 @@ class BoardView extends Base
   function thread_xml()
   {
     global $DB,$Core;
-    
+
     if(!isset($this->data))
     {
       print "No data to display specified.";
       return;
     }
     if(!$this->data) $this->data = array();
-    
+
     if(session('id') && ($this->type == VIEW_THREAD || $this->type == VIEW_MESSAGE) && !$this->ajax)
     {
       if($list = array_keys($Core->list_ignored(session('id')))) $list = implode(",",$list);
@@ -217,7 +217,7 @@ class BoardView extends Base
         $i = $this->collapse+1;
       }
     } // End thread_xml
-   
+
     foreach($this->data as $row)
     {
       $field = $this->prep_data($row);
@@ -254,7 +254,7 @@ class BoardView extends Base
   }
 
   function message() { $this->thread(); }
-  
+
   function member_update()
   {
     global $DB;

--- a/composer.json
+++ b/composer.json
@@ -2,5 +2,7 @@
     "name": "pgboard/pgboard",
     "description": "A pretty good board.",
     "type": "project",
-    "require": {}
+    "require-dev": {
+        "phpstan/phpstan": "^1.10"
+    }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -1,0 +1,81 @@
+{
+    "_readme": [
+        "This file locks the dependencies of your project to a known state",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
+        "This file is @generated automatically"
+    ],
+    "content-hash": "a27004eafdd976397a69829dd721cdf2",
+    "packages": [],
+    "packages-dev": [
+        {
+            "name": "phpstan/phpstan",
+            "version": "1.10.32",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpstan/phpstan.git",
+                "reference": "c47e47d3ab03137c0e121e77c4d2cb58672f6d44"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/c47e47d3ab03137c0e121e77c4d2cb58672f6d44",
+                "reference": "c47e47d3ab03137c0e121e77c4d2cb58672f6d44",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2|^8.0"
+            },
+            "conflict": {
+                "phpstan/phpstan-shim": "*"
+            },
+            "bin": [
+                "phpstan",
+                "phpstan.phar"
+            ],
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "PHPStan - PHP Static Analysis Tool",
+            "keywords": [
+                "dev",
+                "static analysis"
+            ],
+            "support": {
+                "docs": "https://phpstan.org/user-guide/getting-started",
+                "forum": "https://github.com/phpstan/phpstan/discussions",
+                "issues": "https://github.com/phpstan/phpstan/issues",
+                "security": "https://github.com/phpstan/phpstan/security/policy",
+                "source": "https://github.com/phpstan/phpstan-src"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/ondrejmirtes",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/phpstan",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/phpstan/phpstan",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2023-08-24T21:54:50+00:00"
+        }
+    ],
+    "aliases": [],
+    "minimum-stability": "stable",
+    "stability-flags": [],
+    "prefer-stable": false,
+    "prefer-lowest": false,
+    "platform": [],
+    "platform-dev": [],
+    "plugin-api-version": "2.3.0"
+}

--- a/module/chat/get.php
+++ b/module/chat/get.php
@@ -42,7 +42,7 @@ function history_get()
   $output = $last;
   foreach($chats as $chat)
   {
-    $output .= date("h:i:s A",$chat['stamp'])."&nbsp; | ";
+    $output .= date("h:i:s A",(int)$chat['stamp'])."&nbsp; | ";
     $output .= "<strong>".$Core->member_link($chat['name'])."</strong>: ";
     $output .= "<span>".$Parse->run($chat['chat'])."</span><br/>\n";
   }

--- a/module/member/get.php
+++ b/module/member/get.php
@@ -74,24 +74,24 @@ function view_get()
 
   print "<li style=\"padding-top:15px\">\n";
   print "  <div class=\"pref\">date joined:</div>\n";
-  print "  <div class=\"prefdata\">".date(VIEW_DATE_FORMAT,$member['date_joined'])."</div>\n";
+  print "  <div class=\"prefdata\">".date(VIEW_DATE_FORMAT,(int)$member['date_joined'])."</div>\n";
   print "</li>\n";
 
   print "<li>\n";
   print "  <div class=\"pref\">last posted:</div>\n";
-  print "  <div class=\"prefdata\">".date(VIEW_DATE_FORMAT,$member['last_post'])."</div>\n";
+  print "  <div class=\"prefdata\">".date(VIEW_DATE_FORMAT,(int)$member['last_post'])."</div>\n";
   print "</li>\n";
 
   print "<li>\n";
   print "  <div class=\"pref\">last seen:</div>\n";
-  print "  <div class=\"prefdata\">".date(VIEW_DATE_FORMAT,$member['last_view'])."</div>\n";
+  print "  <div class=\"prefdata\">".date(VIEW_DATE_FORMAT,(int)$member['last_view'])."</div>\n";
   print "</li>\n";
 
   print "<li>\n";
   print "  <div class=\"pref\">member:</div>\n";
   print "  <div class=\"prefdata\">$member[id]</div>\n";
   print "</li>\n";
-  
+
   // total threads
   $threads_percent = 0;
   $total_threads = $Core->thread_count();

--- a/module/member/post.php
+++ b/module/member/post.php
@@ -185,13 +185,13 @@ function editcolors_post()
         $val = "#".substr($val,0,6);
         break;
       default:
-        continue;
+        continue 2;
         break;
     }
     $theme[$key] = strip_tags($val);
   }
   $save = serialize($theme);
-  
+
   if($Core->member_pref(session('id'),"theme"))
   {
     $DB->query("UPDATE member_pref SET value=$1 WHERE member_id=$2 AND pref_id=15",array($save,session('id')));

--- a/module/search/get.php
+++ b/module/search/get.php
@@ -50,7 +50,7 @@ function thread_post_get()
   $View->header_menu();
 
   if($res['total'] == 0) $ids = array(0);
-  $DB->query($Query->view_thread(false,cmd(3,true),cmd(4,true),$ids));
+  $DB->query($Query->view_thread(cmd(3, true), cmd(4, true), false, $ids));
   $View->data($DB->load_all());
   $View->thread();
 

--- a/module/search/get.php
+++ b/module/search/get.php
@@ -21,7 +21,7 @@ function thread_get()
   $List->header_menu();
 
   if($res['total'] == 0 || $offset > $res['total']) $ids = array(0);
-  $DB->query($Query->list_thread(false,false,false,$ids));
+  $DB->query($Query->list_thread(false, false, false, $ids));
   $List->data($DB->load_all());
   $List->thread();
 

--- a/module/thread/get.php
+++ b/module/thread/get.php
@@ -128,7 +128,7 @@ function view_get()
 
   $View->header();
 
-  $DB->query($Query->view_thread(id(true),cmd(3,true),cmd(4,true)));
+  $DB->query($Query->view_thread(cmd(3, true), cmd(4, true), id(true)));
   $View->data($DB->load_all());
   if(get('xml'))
   {

--- a/module/thread/get.php
+++ b/module/thread/get.php
@@ -29,16 +29,16 @@ function list_get()
 
 
   // stickies
-  $DB->query($Query->list_thread(true,false,false));
+  $DB->query($Query->list_thread(false, false, true));
   $List->data($DB->load_all());
   if (get('xml')) {
     $xmldata .= $List->thread_xml(true);
   } else {
     $List->thread(true);
   }
-  
+
   // the rest
-  $DB->query($Query->list_thread(false,cmd(2,true),cmd(3,true)));
+  $DB->query($Query->list_thread(cmd(2, true), cmd(3, true)));
   $List->data($DB->load_all());
   if (get('xml')) {
     $xmldata .= $List->thread_xml();
@@ -228,7 +228,7 @@ function listbymemberposted_get()
   $List->subtitle("page: $page");
   $List->header();
 
-  $DB->query($Query->list_thread(false,cmd(3,true),cmd(4,true),$threads));
+  $DB->query($Query->list_thread(cmd(3, true), cmd(4, true), false, $threads));
   $List->data($DB->load_all());
   $List->thread();
 
@@ -271,7 +271,7 @@ function listfavoritesbymember_get()
   $List->subtitle("page: $page");
   $List->header();
 
-  $DB->query($Query->list_thread(false,cmd(3,true),cmd(4,true),$threads));
+  $DB->query($Query->list_thread(cmd(3, true), cmd(4, true), false, $threads));
   $List->data($DB->load_all());
   $List->thread();
 
@@ -314,7 +314,7 @@ function listignoredthreadsbymember_get()
   $List->subtitle("page: $page");
   $List->header();
 
-  $DB->query($Query->list_thread(false,cmd(3,true),cmd(4,true),$threads, false, false));
+  $DB->query($Query->list_thread(cmd(3, true), cmd(4, true), false, $threads, false, false));
   $List->data($DB->load_all());
   $List->thread();
 


### PR DESCRIPTION
See: #8.

This PR updates parts of the codebase for better PHP 8 compatibility. It:

1. Installs PHPStan as a dev dependency so that developers can use it for static analysis.
2. Fixes saveral types of deprecated issues and notices or warnings that were identified via static analysis and the debug console while navigating to different parts of the app:
- Moves optional parameters in function signatures behind required ones (and updates all references to those functions)
- Saves data to a variable before passing it to `end` to squash a pass-by-reference notice.
- Explicitly casts floated string values representing timestamps to `int` before passing them to the `date` method to squash notices about an implicit conversion.
- Uses `continue 2;` in nested control structures (e.g., `switch` within a `foreach`)
- Passes only string values to `str_replace` where an empty replacement is desired.

It's possible other issues will be uncovered during work on the 3.0 milestone. I'll keep the issue and branch open for now and open separate PRs when others are discovered.