### PR TITLE
Add mechanism for seeding database.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,4 +42,4 @@ xdebug-off:
 	docker exec -it pgb-php rm /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini && docker restart pgb-php
 
 db-seed:
-	docker exec -it pgb-php php index.php db:seed
+	docker exec -it pgb-php php bin/console.php db:seed

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,8 @@ help:
 	"\n" start: "\t" Start the Docker container \
 	"\n" stop: "\t\t" Stop the Docker container \
 	"\n" refresh: "\t" Stop, rebuild, and restart the Docker container \
-	"\n" php-shell: "\t" Open a shell session into the PHP container
+	"\n" php-shell: "\t" Open a shell session into the PHP container \
+	"\n" db-seed: "\t" Seed the database with sample data. \
 
 # Starts the Docker container.
 start:

--- a/Makefile
+++ b/Makefile
@@ -42,4 +42,4 @@ xdebug-off:
 	docker exec -it pgb-php rm /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini && docker restart pgb-php
 
 db-seed:
-	docker exec -it pgb-php php bin/console.php db:seed
+	docker exec -it pgb-php php bin/console.php db:seed --no-interaction

--- a/Makefile
+++ b/Makefile
@@ -29,6 +29,9 @@ refresh: stop build-up
 php-shell:
 	docker exec -it pgb-php /bin/bash
 
+db-shell:
+	docker exec -it pgb-postgres psql -U postgres -w
+
 phpstan:
 	docker exec -it pgb-php vendor/bin/phpstan analyse index.php config.php error.php core.php class module
 

--- a/Makefile
+++ b/Makefile
@@ -39,3 +39,6 @@ xdebug-on:
 		&& docker restart pgb-php
 xdebug-off:
 	docker exec -it pgb-php rm /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini && docker restart pgb-php
+
+db-seed:
+	docker exec -it pgb-php php index.php db:seed

--- a/bin/console.php
+++ b/bin/console.php
@@ -1,3 +1,4 @@
+#!/usr/bin/env php
 <?php
 $baseDir = dirname(__DIR__);
 

--- a/class/src/Command/DatabaseSeeder.php
+++ b/class/src/Command/DatabaseSeeder.php
@@ -1,0 +1,25 @@
+<?php
+declare(strict_types=1);
+
+namespace PgBoard\PgBoard\Command;
+
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+#[AsCommand(name: 'db:seed')]
+class DatabaseSeeder extends Command
+{
+  protected function configure()
+  {
+    $this->setDescription('Hello World');
+  }
+
+  protected function execute(InputInterface $input, OutputInterface $output)
+  {
+    $output->write('Seeding database data...', true);
+
+    return Command::SUCCESS;
+  }
+}

--- a/class/src/Command/DatabaseSeeder.php
+++ b/class/src/Command/DatabaseSeeder.php
@@ -92,46 +92,10 @@ class DatabaseSeeder extends Command
       ))->generate();
     }
 
-    $this->generateReplies($helper, $input, $output);
     $this->generateMessages($helper, $input, $output);
     $this->generateChat($helper, $input, $output);
 
     return Command::SUCCESS;
-  }
-
-  public function generateReplies(QuestionHelper $helper, InputInterface $input, OutputInterface $output): void
-  {
-    $default = 1000;
-
-    if (!$input->getOption(self::NON_INTERACTIVE)) {
-      $question = new Question("How many thread replies would you like to generate? (Default: {$default}): ");
-      $count    = $helper->ask($input, $output, $question);
-    }
-
-    $failures = 0;
-
-    if (!is_numeric($count)) {
-      $count = $input->getOption('count') ?? $default;
-    }
-
-    $progressBar = new ProgressBar($output, (int)$count);
-    $progressBar->start();
-
-    for ($i = 0; $i < $count; $i++) {
-      $_SERVER['REMOTE_ADDR'] = $this->faker->ipv4();
-
-      $this->data->thread_post_insert(
-        [
-          'thread_id' => $this->query->getRandomThreadId(),
-          'body'      => $this->faker->paragraphs(rand(1, 10), true),
-        ],
-        $this->query->getRandomMemberId()
-      );
-
-      $progressBar->advance();
-    }
-
-    $progressBar->finish();
   }
 
   private function generateMessages(QuestionHelper $helper, InputInterface $input, OutputInterface $output): void

--- a/class/src/Command/DatabaseSeeder.php
+++ b/class/src/Command/DatabaseSeeder.php
@@ -70,6 +70,7 @@ class DatabaseSeeder extends Command
     $this->generateThreads($helper, $input, $output);
     $this->generateReplies($helper, $input, $output);
     $this->generateMessages($helper, $input, $output);
+    $this->generateChat($helper, $input, $output);
 
     return Command::SUCCESS;
   }
@@ -316,6 +317,35 @@ class DatabaseSeeder extends Command
 
     $successes = $count - $failures;
     $output->writeln(PHP_EOL . "Successfully generated {$successes} messages out of {$count} requested.");
+
+    $progressBar->finish();
+  }
+
+  private function generateChat(QuestionHelper $helper, InputInterface $input, OutputInterface $output)
+  {
+    $default = 1000;
+    $failures = 0;
+
+    if (!$input->getOption(self::NON_INTERACTIVE)) {
+      $question = new Question("How many chat messages would you like to generate? (Default: {$default}): ");
+      $count    = $helper->ask($input, $output, $question);
+    }
+
+    if (!is_numeric($count)) {
+      $count = $input->getOption('count') ?? $default;
+    }
+
+    $progressBar = new ProgressBar($output, $count);
+    $progressBar->start();
+
+    for ($i = 0; $i < $count; $i++) {
+      $this->DB->insert('chat', [
+        'member_id' => $this->getRandomMemberId(),
+        'chat' => $this->faker->realTextBetween(50, 400)
+      ]);
+
+      $progressBar->advance();
+    }
 
     $progressBar->finish();
   }

--- a/class/src/Command/DatabaseSeeder.php
+++ b/class/src/Command/DatabaseSeeder.php
@@ -261,7 +261,7 @@ class DatabaseSeeder extends Command
 
     for ($i = 0; $i < $count; $i++) {
       $memberCount  = rand(1, 5);
-      $member       = $this->getRandomMember();
+      $member       = $this->query->getRandomMember();
       $recipientIds = [];
 
       for ($k = 0; $k < $memberCount; $k++) {
@@ -335,19 +335,5 @@ class DatabaseSeeder extends Command
 
     $successCount = $count - $failures;
     $output->writeln("\nSuccessfully generated {$successCount} chat messages out of {$count} requested.");
-  }
-
-  /**
-   * Get a random user from the database.
-   *
-   * @return array
-   */
-  private function getRandomMember(): array
-  {
-    $result = pg_fetch_all(
-      $this->db->query('SELECT * FROM member WHERE id IN (SELECT random_between(min(id), max(id)) FROM member LIMIT 1)')
-    );
-
-    return !empty($result) ? array_pop($result) : [];
   }
 }

--- a/class/src/Command/DatabaseSeeder.php
+++ b/class/src/Command/DatabaseSeeder.php
@@ -18,6 +18,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 #[AsCommand(name: 'db:seed')]
 class DatabaseSeeder extends Command
 {
+  private const TEST_PASSWORD = 'testing123';
   private DB $DB;
   private Data $Data;
   private Generator $faker;
@@ -60,7 +61,7 @@ class DatabaseSeeder extends Command
         [
           'name'         => $this->faker->userName(),
           'email_signup' => $this->faker->safeEmail(),
-          'pass'         => md5('testing123'),
+          'pass'         => md5(self::TEST_PASSWORD),
           'postalcode'   => $this->faker->postcode(),
           'secret'       => md5($this->faker->word()),
           'ip'           => $this->faker->ipv4(),
@@ -121,7 +122,7 @@ class DatabaseSeeder extends Command
         ob_start();
         $result                 = $this->Data->thread_insert([
           'name' => $memberName,
-          'pass' => 'testing123',
+          'pass' => self::TEST_PASSWORD,
           'subject' => $this->faker->text(),
           'body' => $this->faker->paragraphs(rand(1, 10), true)
         ]);

--- a/class/src/Command/DatabaseSeeder.php
+++ b/class/src/Command/DatabaseSeeder.php
@@ -339,15 +339,20 @@ class DatabaseSeeder extends Command
     $progressBar->start();
 
     for ($i = 0; $i < $count; $i++) {
-      $this->DB->insert('chat', [
+      if(!$this->DB->insert('chat', [
         'member_id' => $this->getRandomMemberId(),
         'chat' => $this->faker->realTextBetween(50, 400)
-      ]);
+      ])) {
+        $failures++;
+      };
 
       $progressBar->advance();
     }
 
     $progressBar->finish();
+
+    $successCount = $count - $failures;
+    $output->writeln("\nSuccessfully generated {$successCount} chat messages out of {$count} requested.");
   }
 
   /**

--- a/class/src/Command/DatabaseSeeder.php
+++ b/class/src/Command/DatabaseSeeder.php
@@ -93,7 +93,7 @@ class DatabaseSeeder extends Command
 
     $failures = 0;
 
-    $progressBar = new ProgressBar($output, $count);
+    $progressBar = new ProgressBar($output, (int)$count);
     $progressBar->start();
 
     for ($i = 0; $i < $count; $i++) {
@@ -236,7 +236,7 @@ class DatabaseSeeder extends Command
       $count = $input->getOption('count') ?? $default;
     }
 
-    $progressBar = new ProgressBar($output, $count);
+    $progressBar = new ProgressBar($output, (int)$count);
     $progressBar->start();
 
 
@@ -298,7 +298,7 @@ class DatabaseSeeder extends Command
       $count = $input->getOption('count') ?? $default;
     }
 
-    $progressBar = new ProgressBar($output, $count);
+    $progressBar = new ProgressBar($output, (int)$count);
     $progressBar->start();
 
     for ($i = 0; $i < $count; $i++) {

--- a/class/src/Command/DatabaseSeeder.php
+++ b/class/src/Command/DatabaseSeeder.php
@@ -8,6 +8,7 @@ use DB;
 use Data;
 use Faker\Factory;
 use Faker\Generator;
+use PgBoard\PgBoard\Command\DatabaseSeeder\ChatGenerator;
 use PgBoard\PgBoard\Command\DatabaseSeeder\DataGenerator;
 use PgBoard\PgBoard\Command\DatabaseSeeder\MemberGenerator;
 use PgBoard\PgBoard\Command\DatabaseSeeder\MessageGenerator;
@@ -43,6 +44,7 @@ class DatabaseSeeder extends Command
     MemberGenerator::class,
     ThreadGenerator::class,
     MessageGenerator::class,
+    ChatGenerator::class,
   ];
 
   protected function configure()
@@ -94,42 +96,6 @@ class DatabaseSeeder extends Command
       ))->generate();
     }
 
-    $this->generateChat($helper, $input, $output);
-
     return Command::SUCCESS;
-  }
-
-  private function generateChat(QuestionHelper $helper, InputInterface $input, OutputInterface $output)
-  {
-    $default  = 1000;
-    $failures = 0;
-
-    if (!$input->getOption(self::NON_INTERACTIVE)) {
-      $question = new Question("How many chat messages would you like to generate? (Default: {$default}): ");
-      $count    = $helper->ask($input, $output, $question);
-    }
-
-    if (!is_numeric($count)) {
-      $count = $input->getOption('count') ?? $default;
-    }
-
-    $progressBar = new ProgressBar($output, (int)$count);
-    $progressBar->start();
-
-    for ($i = 0; $i < $count; $i++) {
-      if (!$this->db->insert('chat', [
-        'member_id' => $this->query->getRandomMemberId(),
-        'chat'      => $this->faker->realTextBetween(50, 400),
-      ])) {
-        $failures++;
-      };
-
-      $progressBar->advance();
-    }
-
-    $progressBar->finish();
-
-    $successCount = $count - $failures;
-    $output->writeln("\nSuccessfully generated {$successCount} chat messages out of {$count} requested.");
   }
 }

--- a/class/src/Command/DatabaseSeeder.php
+++ b/class/src/Command/DatabaseSeeder.php
@@ -3,9 +3,12 @@ declare(strict_types=1);
 
 namespace PgBoard\PgBoard\Command;
 
+use Faker\Factory;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Input\InputDefinition;
 use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
 #[AsCommand(name: 'db:seed')]
@@ -13,13 +16,39 @@ class DatabaseSeeder extends Command
 {
   protected function configure()
   {
-    $this->setDescription('Hello World');
+    $this
+      ->setDescription('Populates the database with fake data to support pgBoard application development.')
+      ->setDefinition(
+          new InputDefinition([
+            new InputOption('all', null, InputOption::VALUE_OPTIONAL, 'Seed the entire application with a sample amount of data.'),
+            new InputOption('table', 't', InputOption::VALUE_OPTIONAL, 'Seed a specific database table with data.'),
+            new InputOption('count', 'c', InputOption::VALUE_OPTIONAL, 'Set the number of records to generate.')
+          ])
+      );
   }
 
   protected function execute(InputInterface $input, OutputInterface $output)
   {
-    $output->write('Seeding database data...', true);
+    global $DB;
 
+    $faker = Factory::create();
+    $count = $input->getOption('count') ?? 1;
+
+    for ($i = 0; $i < $count; $i++) {
+      $DB->insert(
+        'member',
+        [
+          'name'         => $faker->userName(),
+          'email_signup' => $faker->email(),
+          'pass'         => md5($faker->password()),
+          'postalcode'   => $faker->postcode(),
+          'secret'       => md5($faker->word()),
+          'ip'           => $faker->ipv4(),
+        ]
+      );
+    }
+
+    $output->writeln("Seeded {$count} records.");
     return Command::SUCCESS;
   }
 }

--- a/class/src/Command/DatabaseSeeder.php
+++ b/class/src/Command/DatabaseSeeder.php
@@ -99,12 +99,6 @@ class DatabaseSeeder extends Command
     return Command::SUCCESS;
   }
 
-  private function getMemberNameById($memberId)
-  {
-    return pg_fetch_result($this->db->query("SELECT name FROM member WHERE id = $1", [$memberId]), 0, 0);
-  }
-
-
   public function generateReplies(QuestionHelper $helper, InputInterface $input, OutputInterface $output): void
   {
     $default = 1000;

--- a/class/src/Command/DatabaseSeeder.php
+++ b/class/src/Command/DatabaseSeeder.php
@@ -4,8 +4,10 @@ declare(strict_types=1);
 namespace PgBoard\PgBoard\Command;
 
 use DB;
+use Data;
 use Faker\Factory;
 use Faker\Generator;
+use PgSql\Result;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Input\InputDefinition;
@@ -17,6 +19,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 class DatabaseSeeder extends Command
 {
   private DB $DB;
+  private Data $Data;
   private Generator $faker;
 
   protected function configure()
@@ -34,12 +37,14 @@ class DatabaseSeeder extends Command
 
   protected function execute(InputInterface $input, OutputInterface $output)
   {
-    global $DB;
+    global $DB, $Security;
 
     $this->DB = $DB;
+    $this->Data = new Data($DB, $Security);
     $this->faker = Factory::create();
 
     $this->generateMembers($input, $output);
+    $this->generateThreads($input, $output);
 
     return Command::SUCCESS;
   }
@@ -55,7 +60,7 @@ class DatabaseSeeder extends Command
         [
           'name'         => $this->faker->userName(),
           'email_signup' => $this->faker->safeEmail(),
-          'pass'         => md5($this->faker->password()),
+          'pass'         => md5('testing123'),
           'postalcode'   => $this->faker->postcode(),
           'secret'       => md5($this->faker->word()),
           'ip'           => $this->faker->ipv4(),
@@ -76,6 +81,62 @@ class DatabaseSeeder extends Command
       sprintf(
         "Successfully generated %d member records.",
         $count - $failures,
+      )
+    );
+  }
+
+  private function generateThreads(InputInterface $input, OutputInterface $output)
+  {
+    $count = $input->getOption('count') ?? 1000;
+    $failures = 0;
+
+    $indexQuery = <<<SQL
+        CREATE OR REPLACE FUNCTION random_between(low integer, high integer)
+               RETURNS integer
+               LANGUAGE plpgsql
+               STRICT
+               AS \$function\$
+               BEGIN
+                RETURN floor(random()* (high-low +1) + low);
+               END;
+              \$function\$;
+    SQL;
+
+    $result = $this->DB->query($indexQuery);
+
+    if (is_bool($result)) {
+      $output->writeln("Failed to create random_between function.");
+    }
+
+    for ($i = 0; $i < $count; $i++) {
+      try {
+        $_SERVER['REMOTE_ADDR'] = $this->faker->ipv4();
+        $memberId = pg_fetch_result(
+          $this->DB->query("SELECT random_between(min(id), max(id)) from member"),
+          0,
+          0
+        );
+        $memberName = pg_fetch_result($this->DB->query("SELECT name FROM member WHERE id = $1", [$memberId]), 0, 0);
+
+        ob_start();
+        $result                 = $this->Data->thread_insert([
+          'name' => $memberName,
+          'pass' => 'testing123',
+          'subject' => $this->faker->text(),
+          'body' => $this->faker->paragraphs(rand(1, 10), true)
+        ]);
+        ob_end_clean();
+      } catch (\Throwable $e) {
+        $failures++;
+        continue;
+      }
+    }
+
+    $output->writeln(
+      sprintf(
+        "Successfully generated %d new threads out of %d requested.",
+        $count - $failures,
+        $count,
       )
     );
   }

--- a/class/src/Command/DatabaseSeeder.php
+++ b/class/src/Command/DatabaseSeeder.php
@@ -131,15 +131,6 @@ class DatabaseSeeder extends Command
     $progressBar->finish();
   }
 
-  private function getRandomMemberId(): int
-  {
-    return (int)pg_fetch_result(
-      $this->db->query("SELECT random_between(min(id), max(id)) from member LIMIT 1"),
-      0,
-      0
-    );
-  }
-
   private function getMemberNameById($memberId)
   {
     return pg_fetch_result($this->db->query("SELECT name FROM member WHERE id = $1", [$memberId]), 0, 0);
@@ -174,7 +165,7 @@ class DatabaseSeeder extends Command
     for ($i = 0; $i < $count; $i++) {
       try {
         $_SERVER['REMOTE_ADDR'] = $this->faker->ipv4();
-        $memberId               = $this->getRandomMemberId();
+        $memberId               = $this->query->getRandomMemberId();
         $memberName             = $this->getMemberNameById($memberId);
 
         ob_start();
@@ -232,7 +223,7 @@ class DatabaseSeeder extends Command
           'thread_id' => $this->getRandomThreadId(),
           'body'      => $this->faker->paragraphs(rand(1, 10), true),
         ],
-        $this->getRandomMemberId()
+        $this->query->getRandomMemberId()
       );
 
       $progressBar->advance();
@@ -265,7 +256,7 @@ class DatabaseSeeder extends Command
       $recipientIds = [];
 
       for ($k = 0; $k < $memberCount; $k++) {
-        $recipientIds[] = $this->getRandomMemberId();
+        $recipientIds[] = $this->query->getRandomMemberId();
       }
 
       if (!in_array($member['id'], $recipientIds, true)) {
@@ -322,7 +313,7 @@ class DatabaseSeeder extends Command
 
     for ($i = 0; $i < $count; $i++) {
       if (!$this->db->insert('chat', [
-        'member_id' => $this->getRandomMemberId(),
+        'member_id' => $this->query->getRandomMemberId(),
         'chat'      => $this->faker->realTextBetween(50, 400),
       ])) {
         $failures++;

--- a/class/src/Command/DatabaseSeeder.php
+++ b/class/src/Command/DatabaseSeeder.php
@@ -136,15 +136,6 @@ class DatabaseSeeder extends Command
     return pg_fetch_result($this->db->query("SELECT name FROM member WHERE id = $1", [$memberId]), 0, 0);
   }
 
-  private function getRandomThreadId(): int
-  {
-    return (int)pg_fetch_result(
-      $this->db->query("SELECT random_between(min(id), max(id)) from thread"),
-      0,
-      0
-    );
-  }
-
   private function generateThreads(QuestionHelper $helper, InputInterface $input, OutputInterface $output)
   {
     $default = 1000;
@@ -165,12 +156,11 @@ class DatabaseSeeder extends Command
     for ($i = 0; $i < $count; $i++) {
       try {
         $_SERVER['REMOTE_ADDR'] = $this->faker->ipv4();
-        $memberId               = $this->query->getRandomMemberId();
-        $memberName             = $this->getMemberNameById($memberId);
+        $member = $this->query->getRandomMember();
 
         ob_start();
         $result = $this->data->thread_insert([
-          'name'    => $memberName,
+          'name'    => $member['name'],
           'pass'    => self::TEST_PASSWORD,
           'subject' => $this->faker->text(),
           'body'    => $this->faker->paragraphs(rand(1, 10), true),
@@ -220,7 +210,7 @@ class DatabaseSeeder extends Command
 
       $this->data->thread_post_insert(
         [
-          'thread_id' => $this->getRandomThreadId(),
+          'thread_id' => $this->query->getRandomThreadId(),
           'body'      => $this->faker->paragraphs(rand(1, 10), true),
         ],
         $this->query->getRandomMemberId()
@@ -270,7 +260,7 @@ class DatabaseSeeder extends Command
         [
           'name'            => $member['name'],
           'pass'            => self::TEST_PASSWORD,
-          'thread_id'       => $this->getRandomThreadId(),
+          'thread_id'       => $this->query->getRandomThreadId(),
           'subject'         => $this->faker->text(),
           'body'            => $this->faker->paragraphs(rand(1, 10), true),
           'message_members' => implode(',', array_unique(array_filter($recipientIds))),

--- a/class/src/Command/DatabaseSeeder.php
+++ b/class/src/Command/DatabaseSeeder.php
@@ -39,7 +39,7 @@ class DatabaseSeeder extends Command
         'member',
         [
           'name'         => $faker->userName(),
-          'email_signup' => $faker->email(),
+          'email_signup' => $faker->safeEmail(),
           'pass'         => md5($faker->password()),
           'postalcode'   => $faker->postcode(),
           'secret'       => md5($faker->word()),

--- a/class/src/Command/DatabaseSeeder.php
+++ b/class/src/Command/DatabaseSeeder.php
@@ -27,6 +27,8 @@ class DatabaseSeeder extends Command
   private Generator $faker;
   private ProgressBar $progressBar;
 
+  private const NON_INTERACTIVE = 'no-interaction';
+
   protected function configure()
   {
     $this
@@ -35,7 +37,7 @@ class DatabaseSeeder extends Command
           new InputDefinition([
             new InputOption('all', null, InputOption::VALUE_OPTIONAL, 'Seed the entire application with a sample amount of data.'),
             new InputOption('table', 't', InputOption::VALUE_OPTIONAL, 'Seed a specific database table with data.'),
-            new InputOption('count', 'c', InputOption::VALUE_OPTIONAL, 'Set the number of records to generate.')
+            new InputOption('count', 'c', InputOption::VALUE_OPTIONAL, 'Set the number of records to generate.'),
           ])
       );
   }
@@ -68,8 +70,11 @@ class DatabaseSeeder extends Command
   private function generateMembers(QuestionHelper $helper, InputInterface $input, OutputInterface $output)
   {
     $default = 1000;
-    $question = new Question("How many members would you like to generate? (Default: {$default}): ");
-    $count = $helper->ask($input, $output, $question);
+
+    if (!$input->getOption(self::NON_INTERACTIVE)) {
+      $question = new Question("How many members would you like to generate? (Default: {$default}): ");
+      $count = $helper->ask($input, $output, $question);
+    }
 
     if (!is_numeric($count)) {
       $count = $input->getOption('count') ?? $default;
@@ -157,8 +162,11 @@ class DatabaseSeeder extends Command
   private function generateThreads(QuestionHelper $helper, InputInterface $input, OutputInterface $output)
   {
     $default = 1000;
-    $question = new Question("How many threads would you like to generate? (Default: {$default}): ");
-    $count = $helper->ask($input, $output, $question);
+
+    if (!$input->getOption(self::NON_INTERACTIVE)) {
+      $question = new Question("How many threads would you like to generate? (Default: {$default}): ");
+      $count = $helper->ask($input, $output, $question);
+    }
 
     if (!is_numeric($count)) {
       $count = $input->getOption('count') ?? $default;
@@ -205,8 +213,12 @@ class DatabaseSeeder extends Command
   public function generateReplies(QuestionHelper $helper, InputInterface $input, OutputInterface $output): void
   {
     $default = 1000;
-    $question = new Question("How many thread replies would you like to generate? (Default: {$default}): ");
-    $count    = $helper->ask($input, $output, $question);
+
+    if (!$input->getOption(self::NON_INTERACTIVE)) {
+      $question = new Question("How many thread replies would you like to generate? (Default: {$default}): ");
+      $count    = $helper->ask($input, $output, $question);
+    }
+
     $failures = 0;
 
     if (!is_numeric($count)) {

--- a/class/src/Command/DatabaseSeeder.php
+++ b/class/src/Command/DatabaseSeeder.php
@@ -52,6 +52,12 @@ class DatabaseSeeder extends Command
 
     $helper = $this->getHelper('question');
 
+    try {
+      $this->createRandomizationQuery();
+    } catch (\Exception $e) {
+      $output->writeln($e->getMessage());
+    }
+
     $this->generateMembers($helper, $input, $output);
     $this->generateThreads($helper, $input, $output);
     $this->generateReplies($helper, $input, $output);
@@ -61,16 +67,17 @@ class DatabaseSeeder extends Command
 
   private function generateMembers(QuestionHelper $helper, InputInterface $input, OutputInterface $output)
   {
-    $question = new Question('How many members would you like to generate? ');
+    $default = 1000;
+    $question = new Question("How many members would you like to generate? (Default: {$default}): ");
     $count = $helper->ask($input, $output, $question);
 
     if (!is_numeric($count)) {
-      $count = $input->getOption('count') ?? 1000;
+      $count = $input->getOption('count') ?? $default;
     }
 
     $failures = 0;
 
-    $progressBar = new ProgressBar($output, (int) $count);
+    $progressBar = new ProgressBar($output, $count);
     $progressBar->start();
 
     for ($i = 0; $i < $count; $i++) {
@@ -149,21 +156,15 @@ class DatabaseSeeder extends Command
 
   private function generateThreads(QuestionHelper $helper, InputInterface $input, OutputInterface $output)
   {
-    $question = new Question('How many threads would you like to generate? ');
+    $default = 1000;
+    $question = new Question("How many threads would you like to generate? (Default: {$default}): ");
     $count = $helper->ask($input, $output, $question);
 
     if (!is_numeric($count)) {
-      $count = $input->getOption('count') ?? 1000;
+      $count = $input->getOption('count') ?? $default;
     }
 
     $failures = 0;
-
-    try {
-      $this->createRandomizationQuery();
-    } catch (\Exception $e) {
-      $output->writeln($e->getMessage());
-    }
-
     $progressBar = new ProgressBar($output, (int) $count);
     $progressBar->start();
 
@@ -203,12 +204,13 @@ class DatabaseSeeder extends Command
 
   public function generateReplies(QuestionHelper $helper, InputInterface $input, OutputInterface $output): void
   {
-    $question = new Question('How many thread replies would you like to generate? ');
+    $default = 1000;
+    $question = new Question("How many thread replies would you like to generate? (Default: {$default}): ");
     $count    = $helper->ask($input, $output, $question);
     $failures = 0;
 
     if (!is_numeric($count)) {
-      $count = $input->getOption('count') ?? 1000;
+      $count = $input->getOption('count') ?? $default;
     }
 
     $progressBar = new ProgressBar($output, (int) $count);

--- a/class/src/Command/DatabaseSeeder.php
+++ b/class/src/Command/DatabaseSeeder.php
@@ -8,12 +8,7 @@ use DB;
 use Data;
 use Faker\Factory;
 use Faker\Generator;
-use PgBoard\PgBoard\Command\DatabaseSeeder\ChatGenerator;
-use PgBoard\PgBoard\Command\DatabaseSeeder\DataGenerator;
-use PgBoard\PgBoard\Command\DatabaseSeeder\MemberGenerator;
-use PgBoard\PgBoard\Command\DatabaseSeeder\MessageGenerator;
-use PgBoard\PgBoard\Command\DatabaseSeeder\Query;
-use PgBoard\PgBoard\Command\DatabaseSeeder\ThreadGenerator;
+use PgBoard\PgBoard\Command\DatabaseSeeder as Seeder;
 use PgSql\Result;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Attribute\AsCommand;
@@ -33,7 +28,7 @@ class DatabaseSeeder extends Command
 
   private DB $db;
   private Data $data;
-  private Query $query;
+  private Seeder\Query $query;
   private Generator $faker;
   private ProgressBar $progressBar;
 
@@ -41,10 +36,10 @@ class DatabaseSeeder extends Command
    * @var DataGenerator[]
    */
   private array $generators = [
-    MemberGenerator::class,
-    ThreadGenerator::class,
-    MessageGenerator::class,
-    ChatGenerator::class,
+    Seeder\MemberGenerator::class,
+    Seeder\ThreadGenerator::class,
+    Seeder\MessageGenerator::class,
+    Seeder\ChatGenerator::class,
   ];
 
   protected function configure()
@@ -73,7 +68,7 @@ class DatabaseSeeder extends Command
 
     $this->db    = $DB;
     $this->data  = new Data($DB, $Security);
-    $this->query = new Query($DB);
+    $this->query = new Seeder\Query($DB);
     $this->faker = Factory::create();
 
     $helper = $this->getHelper('question');

--- a/class/src/Command/DatabaseSeeder.php
+++ b/class/src/Command/DatabaseSeeder.php
@@ -10,10 +10,12 @@ use Faker\Generator;
 use PgSql\Result;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Helper\QuestionHelper;
 use Symfony\Component\Console\Input\InputDefinition;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Question\Question;
 
 #[AsCommand(name: 'db:seed')]
 class DatabaseSeeder extends Command
@@ -44,15 +46,23 @@ class DatabaseSeeder extends Command
     $this->Data = new Data($DB, $Security);
     $this->faker = Factory::create();
 
-    $this->generateMembers($input, $output);
-    $this->generateThreads($input, $output);
+    $helper = $this->getHelper('question');
+
+    $this->generateMembers($helper, $input, $output);
+    $this->generateThreads($helper, $input, $output);
 
     return Command::SUCCESS;
   }
 
-  private function generateMembers(InputInterface $input, OutputInterface $output)
+  private function generateMembers(QuestionHelper $helper, InputInterface $input, OutputInterface $output)
   {
-    $count = $input->getOption('count') ?? 1000;
+    $question = new Question('How many members would you like to generate? ');
+    $count = $helper->ask($input, $output, $question);
+
+    if (!is_numeric($count)) {
+      $count = $input->getOption('count') ?? 1000;
+    }
+
     $failures = 0;
 
     for ($i = 0; $i < $count; $i++) {
@@ -86,9 +96,15 @@ class DatabaseSeeder extends Command
     );
   }
 
-  private function generateThreads(InputInterface $input, OutputInterface $output)
+  private function generateThreads(QuestionHelper $helper, InputInterface $input, OutputInterface $output)
   {
-    $count = $input->getOption('count') ?? 1000;
+    $question = new Question('How many threads would you like to generate? ');
+    $count = $helper->ask($input, $output, $question);
+
+    if (!is_numeric($count)) {
+      $count = $input->getOption('count') ?? 1000;
+    }
+
     $failures = 0;
 
     $indexQuery = <<<SQL

--- a/class/src/Command/DatabaseSeeder/ChatGenerator.php
+++ b/class/src/Command/DatabaseSeeder/ChatGenerator.php
@@ -1,0 +1,45 @@
+<?php
+declare(strict_types=1);
+
+namespace PgBoard\PgBoard\Command\DatabaseSeeder;
+
+use PgBoard\PgBoard\Command\DatabaseSeeder;
+use Symfony\Component\Console\Helper\ProgressBar;
+use Symfony\Component\Console\Question\Question;
+
+class ChatGenerator extends DataGenerator
+{
+  public function generate(): void
+  {
+    $default  = 1000;
+    $failures = 0;
+
+    if (!$this->input->getOption(DatabaseSeeder::NON_INTERACTIVE)) {
+      $question = new Question("How many chat messages would you like to generate? (Default: {$default}): ");
+      $count    = $helper->ask($this->input, $this->output, $question);
+    }
+
+    if (!is_numeric($count)) {
+      $count = $this->input->getOption('count') ?? $default;
+    }
+
+    $progressBar = new ProgressBar($this->output, (int)$count);
+    $progressBar->start();
+
+    for ($i = 0; $i < $count; $i++) {
+      if (!$this->db->insert('chat', [
+        'member_id' => $this->query->getRandomMemberId(),
+        'chat'      => $this->faker->realTextBetween(50, 400),
+      ])) {
+        $failures++;
+      };
+
+      $progressBar->advance();
+    }
+
+    $progressBar->finish();
+
+    $successCount = $count - $failures;
+    $this->output->writeln("\nSuccessfully generated {$successCount} chat messages out of {$count} requested.");
+  }
+}

--- a/class/src/Command/DatabaseSeeder/ChatGenerator.php
+++ b/class/src/Command/DatabaseSeeder/ChatGenerator.php
@@ -23,6 +23,13 @@ class ChatGenerator extends DataGenerator
       $count = $this->input->getOption('count') ?? $default;
     }
 
+    $this->output->writeln(
+      sprintf(
+        "\nAttempting to generate %d chat posts...",
+        $count
+      )
+    );
+
     $progressBar = new ProgressBar($this->output, (int)$count);
     $progressBar->start();
 
@@ -39,7 +46,11 @@ class ChatGenerator extends DataGenerator
 
     $progressBar->finish();
 
-    $successCount = $count - $failures;
-    $this->output->writeln("\nSuccessfully generated {$successCount} chat messages out of {$count} requested.");
+    $this->output->writeln(
+      sprintf(
+        "\nSuccessfully generated %d chat posts.",
+        $count - $failures
+      )
+    );
   }
 }

--- a/class/src/Command/DatabaseSeeder/DataGenerator.php
+++ b/class/src/Command/DatabaseSeeder/DataGenerator.php
@@ -1,0 +1,26 @@
+<?php
+declare(strict_types=1);
+
+namespace PgBoard\PgBoard\Command\DatabaseSeeder;
+
+use DB;
+use Data;
+use Faker\Generator;
+use Symfony\Component\Console\Helper\QuestionHelper;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+abstract class DataGenerator
+{
+  public function __construct(
+    protected readonly DB $db,
+    protected readonly Data $data,
+    protected readonly Query $query,
+    protected readonly Generator $faker,
+    protected readonly QuestionHelper $helper,
+    protected readonly InputInterface $input,
+    protected readonly OutputInterface $output
+  ) {}
+
+  abstract public function generate(): void;
+}

--- a/class/src/Command/DatabaseSeeder/MemberGenerator.php
+++ b/class/src/Command/DatabaseSeeder/MemberGenerator.php
@@ -12,6 +12,7 @@ class MemberGenerator extends DataGenerator
   public function generate(): void
   {
     $default = 1000;
+    $failures = 0;
 
     if (!$this->input->getOption(DatabaseSeeder::NON_INTERACTIVE)) {
       $question = new Question("How many members would you like to generate? (Default: {$default}): ");
@@ -22,7 +23,12 @@ class MemberGenerator extends DataGenerator
       $count = $this->input->getOption('count') ?? $default;
     }
 
-    $failures = 0;
+    $this->output->writeln(
+      sprintf(
+        "\nAttempting to generate %d members...",
+        $count
+      )
+    );
 
     $progressBar = new ProgressBar($this->output, (int)$count);
     $progressBar->start();

--- a/class/src/Command/DatabaseSeeder/MemberGenerator.php
+++ b/class/src/Command/DatabaseSeeder/MemberGenerator.php
@@ -1,0 +1,64 @@
+<?php
+declare(strict_types=1);
+
+namespace PgBoard\PgBoard\Command\DatabaseSeeder;
+
+use PgBoard\PgBoard\Command\DatabaseSeeder;
+use Symfony\Component\Console\Helper\ProgressBar;
+use Symfony\Component\Console\Question\Question;
+
+class MemberGenerator extends DataGenerator
+{
+  public function generate(): void
+  {
+    $default = 1000;
+
+    if (!$this->input->getOption(DatabaseSeeder::NON_INTERACTIVE)) {
+      $question = new Question("How many members would you like to generate? (Default: {$default}): ");
+      $count    = $helper->ask($this->input, $this->output, $question);
+    }
+
+    if (!is_numeric($count)) {
+      $count = $this->input->getOption('count') ?? $default;
+    }
+
+    $failures = 0;
+
+    $progressBar = new ProgressBar($this->output, (int)$count);
+    $progressBar->start();
+
+    for ($i = 0; $i < $count; $i++) {
+      $result = $this->db->insert(
+        'member',
+        [
+          'name'         => $this->faker->userName(),
+          'email_signup' => $this->faker->safeEmail(),
+          'pass'         => md5(DatabaseSeeder::TEST_PASSWORD),
+          'postalcode'   => $this->faker->postcode(),
+          'secret'       => md5($this->faker->word()),
+          'ip'           => $this->faker->ipv4(),
+        ]
+      );
+
+      /*
+       * Because database inserts fail silently, we don't know what specifically caused the error with the
+       * insert query. For now, increment the failure and deduct it from the total requested so we can report
+       * back the number of records that were added.
+       */
+      if (is_bool($result)) {
+        $failures++;
+      }
+
+      $progressBar->advance();
+    }
+
+    $progressBar->finish();
+
+    $this->output->writeln(
+      sprintf(
+        "\nSuccessfully generated %d member records.",
+        $count - $failures,
+      )
+    );
+  }
+}

--- a/class/src/Command/DatabaseSeeder/MessageGenerator.php
+++ b/class/src/Command/DatabaseSeeder/MessageGenerator.php
@@ -23,9 +23,15 @@ class MessageGenerator extends DataGenerator
       $count = $this->input->getOption('count') ?? $default;
     }
 
+    $this->output->writeln(
+      sprintf(
+        "\nAttempting to generate %d member messages...",
+        $count
+      )
+    );
+
     $progressBar = new ProgressBar($this->output, (int)$count);
     $progressBar->start();
-
 
     for ($i = 0; $i < $count; $i++) {
       $memberCount  = rand(1, 5);
@@ -65,8 +71,12 @@ class MessageGenerator extends DataGenerator
       $progressBar->advance();
     }
 
-    $successes = $count - $failures;
-    $this->output->writeln(PHP_EOL . "Successfully generated {$successes} messages out of {$count} requested.");
+    $this->output->writeln(
+      sprintf(
+        "\nSuccessfully generated %d messages.",
+        $count - $failures
+      )
+    );
 
     $progressBar->finish();
   }

--- a/class/src/Command/DatabaseSeeder/MessageGenerator.php
+++ b/class/src/Command/DatabaseSeeder/MessageGenerator.php
@@ -1,0 +1,73 @@
+<?php
+declare(strict_types=1);
+
+namespace PgBoard\PgBoard\Command\DatabaseSeeder;
+
+use PgBoard\PgBoard\Command\DatabaseSeeder;
+use Symfony\Component\Console\Helper\ProgressBar;
+use Symfony\Component\Console\Question\Question;
+
+class MessageGenerator extends DataGenerator
+{
+  public function generate(): void
+  {
+    $default  = 1000;
+    $failures = 0;
+
+    if (!$this->input->getOption(DatabaseSeeder::NON_INTERACTIVE)) {
+      $question = new Question("How many messages would you like to generate? (Default: {$default}): ");
+      $count    = $helper->ask($this->input, $this->output, $question);
+    }
+
+    if (!is_numeric($count)) {
+      $count = $this->input->getOption('count') ?? $default;
+    }
+
+    $progressBar = new ProgressBar($this->output, (int)$count);
+    $progressBar->start();
+
+
+    for ($i = 0; $i < $count; $i++) {
+      $memberCount  = rand(1, 5);
+      $member       = $this->query->getRandomMember();
+      $recipientIds = [];
+
+      for ($k = 0; $k < $memberCount; $k++) {
+        $recipientIds[] = $this->query->getRandomMemberId();
+      }
+
+      if (!in_array($member['id'], $recipientIds, true)) {
+        $recipientIds[] = $member['id'];
+      }
+
+      $_SERVER['REMOTE_ADDR'] = $this->faker->ipv4();
+
+      ob_start();
+      if (!$this->data->message_insert(
+        [
+          'name'            => $member['name'],
+          'pass'            => DatabaseSeeder::TEST_PASSWORD,
+          'thread_id'       => $this->query->getRandomThreadId(),
+          'subject'         => $this->faker->text(),
+          'body'            => $this->faker->paragraphs(rand(1, 10), true),
+          'message_members' => implode(',', array_unique(array_filter($recipientIds))),
+        ],
+        $member['id'],
+      )
+      ) {
+        ob_end_clean();
+        $failures++;
+        $progressBar->advance();
+        continue;
+      }
+
+      ob_end_clean();
+      $progressBar->advance();
+    }
+
+    $successes = $count - $failures;
+    $this->output->writeln(PHP_EOL . "Successfully generated {$successes} messages out of {$count} requested.");
+
+    $progressBar->finish();
+  }
+}

--- a/class/src/Command/DatabaseSeeder/Query.php
+++ b/class/src/Command/DatabaseSeeder/Query.php
@@ -45,4 +45,13 @@ class Query
 
     return !empty($result) ? array_pop($result) : [];
   }
+
+  public function getRandomMemberId(): int
+  {
+    return (int)pg_fetch_result(
+      $this->db->query("SELECT random_between(min(id), max(id)) from member LIMIT 1"),
+      0,
+      0
+    );
+  }
 }

--- a/class/src/Command/DatabaseSeeder/Query.php
+++ b/class/src/Command/DatabaseSeeder/Query.php
@@ -31,4 +31,18 @@ class Query
       throw new \Exception("Failed to create random_between function.");
     }
   }
+
+  /**
+   * Get a random user from the database.
+   *
+   * @return array
+   */
+  public function getRandomMember(): array
+  {
+    $result = pg_fetch_all(
+      $this->db->query('SELECT * FROM member WHERE id IN (SELECT random_between(min(id), max(id)) FROM member LIMIT 1)')
+    );
+
+    return !empty($result) ? array_pop($result) : [];
+  }
 }

--- a/class/src/Command/DatabaseSeeder/Query.php
+++ b/class/src/Command/DatabaseSeeder/Query.php
@@ -54,4 +54,13 @@ class Query
       0
     );
   }
+
+  public function getRandomThreadId(): int
+  {
+    return (int)pg_fetch_result(
+      $this->db->query("SELECT random_between(min(id), max(id)) from thread"),
+      0,
+      0
+    );
+  }
 }

--- a/class/src/Command/DatabaseSeeder/Query.php
+++ b/class/src/Command/DatabaseSeeder/Query.php
@@ -1,0 +1,34 @@
+<?php
+declare(strict_types=1);
+
+namespace PgBoard\PgBoard\Command\DatabaseSeeder;
+
+use DB;
+
+class Query
+{
+  public function __construct(
+    private readonly DB $db
+  ) {}
+
+  public function createRandomizationQuery(): void
+  {
+    $indexQuery = <<<SQL
+        CREATE OR REPLACE FUNCTION random_between(low integer, high integer)
+               RETURNS integer
+               LANGUAGE plpgsql
+               STRICT
+               AS \$function\$
+               BEGIN
+                RETURN floor(random()* (high-low +1) + low);
+               END;
+              \$function\$;
+    SQL;
+
+    $result = $this->db->query($indexQuery);
+
+    if (is_bool($result)) {
+      throw new \Exception("Failed to create random_between function.");
+    }
+  }
+}

--- a/class/src/Command/DatabaseSeeder/ThreadGenerator.php
+++ b/class/src/Command/DatabaseSeeder/ThreadGenerator.php
@@ -17,6 +17,7 @@ class ThreadGenerator extends DataGenerator
 
   private function generateThreads(): void {
     $default = 1000;
+    $failures    = 0;
 
     if (!$this->input->getOption(DatabaseSeeder::NON_INTERACTIVE)) {
       $question = new Question("How many threads would you like to generate? (Default: {$default}): ");
@@ -27,7 +28,13 @@ class ThreadGenerator extends DataGenerator
       $count = $this->input->getOption('count') ?? $default;
     }
 
-    $failures    = 0;
+    $this->output->writeln(
+      sprintf(
+        "\nAttempting to generate %d new threads...",
+        $count
+      )
+    );
+
     $progressBar = new ProgressBar($this->output, (int)$count);
     $progressBar->start();
 
@@ -58,9 +65,8 @@ class ThreadGenerator extends DataGenerator
 
     $this->output->writeln(
       sprintf(
-        "\nSuccessfully generated %d new threads out of %d requested.",
+        "\nSuccessfully generated %d new threads.",
         $count - $failures,
-        $count,
       )
     );
   }
@@ -80,23 +86,39 @@ class ThreadGenerator extends DataGenerator
       $count = $this->input->getOption('count') ?? $default;
     }
 
+    $this->output->writeln(
+      sprintf(
+        "\nAttempting to generate %d thread replies...",
+        $count
+      )
+    );
+
     $progressBar = new ProgressBar($this->output, (int)$count);
     $progressBar->start();
 
     for ($i = 0; $i < $count; $i++) {
       $_SERVER['REMOTE_ADDR'] = $this->faker->ipv4();
 
-      $this->data->thread_post_insert(
+      if(!$this->data->thread_post_insert(
         [
           'thread_id' => $this->query->getRandomThreadId(),
           'body'      => $this->faker->paragraphs(rand(1, 10), true),
         ],
         $this->query->getRandomMemberId()
-      );
+      )) {
+        $failures++;
+      };
 
       $progressBar->advance();
     }
 
     $progressBar->finish();
+
+    $this->output->writeln(
+      sprintf(
+        "\nSuccessfully generated %d thread replies.",
+        $count - $failures,
+      )
+    );
   }
 }

--- a/class/src/Command/DatabaseSeeder/ThreadGenerator.php
+++ b/class/src/Command/DatabaseSeeder/ThreadGenerator.php
@@ -11,6 +11,11 @@ class ThreadGenerator extends DataGenerator
 {
   public function generate(): void
   {
+    $this->generateThreads();
+    $this->generateReplies();
+  }
+
+  private function generateThreads(): void {
     $default = 1000;
 
     if (!$this->input->getOption(DatabaseSeeder::NON_INTERACTIVE)) {
@@ -58,5 +63,40 @@ class ThreadGenerator extends DataGenerator
         $count,
       )
     );
+  }
+
+  private function generateReplies(): void
+  {
+    $default = 1000;
+
+    if (!$this->input->getOption(DatabaseSeeder::NON_INTERACTIVE)) {
+      $question = new Question("How many thread replies would you like to generate? (Default: {$default}): ");
+      $count    = $helper->ask($this->input, $this->output, $question);
+    }
+
+    $failures = 0;
+
+    if (!is_numeric($count)) {
+      $count = $this->input->getOption('count') ?? $default;
+    }
+
+    $progressBar = new ProgressBar($this->output, (int)$count);
+    $progressBar->start();
+
+    for ($i = 0; $i < $count; $i++) {
+      $_SERVER['REMOTE_ADDR'] = $this->faker->ipv4();
+
+      $this->data->thread_post_insert(
+        [
+          'thread_id' => $this->query->getRandomThreadId(),
+          'body'      => $this->faker->paragraphs(rand(1, 10), true),
+        ],
+        $this->query->getRandomMemberId()
+      );
+
+      $progressBar->advance();
+    }
+
+    $progressBar->finish();
   }
 }

--- a/class/src/Command/DatabaseSeeder/ThreadGenerator.php
+++ b/class/src/Command/DatabaseSeeder/ThreadGenerator.php
@@ -1,0 +1,62 @@
+<?php
+declare(strict_types=1);
+
+namespace PgBoard\PgBoard\Command\DatabaseSeeder;
+
+use PgBoard\PgBoard\Command\DatabaseSeeder;
+use Symfony\Component\Console\Helper\ProgressBar;
+use Symfony\Component\Console\Question\Question;
+
+class ThreadGenerator extends DataGenerator
+{
+  public function generate(): void
+  {
+    $default = 1000;
+
+    if (!$this->input->getOption(DatabaseSeeder::NON_INTERACTIVE)) {
+      $question = new Question("How many threads would you like to generate? (Default: {$default}): ");
+      $count    = $helper->ask($this->input, $this->output, $question);
+    }
+
+    if (!is_numeric($count)) {
+      $count = $this->input->getOption('count') ?? $default;
+    }
+
+    $failures    = 0;
+    $progressBar = new ProgressBar($this->output, (int)$count);
+    $progressBar->start();
+
+    for ($i = 0; $i < $count; $i++) {
+      try {
+        $_SERVER['REMOTE_ADDR'] = $this->faker->ipv4();
+        $member = $this->query->getRandomMember();
+
+        ob_start();
+        $result = $this->data->thread_insert([
+          'name'    => $member['name'],
+          'pass'    => DatabaseSeeder::TEST_PASSWORD,
+          'subject' => $this->faker->text(),
+          'body'    => $this->faker->paragraphs(rand(1, 10), true),
+        ]);
+
+        ob_end_clean();
+      } catch (\Throwable $e) {
+        $failures++;
+        $this->output->writeln($e->getMessage());
+        continue;
+      } finally {
+        $progressBar->advance();
+      }
+    }
+
+    $progressBar->finish();
+
+    $this->output->writeln(
+      sprintf(
+        "\nSuccessfully generated %d new threads out of %d requested.",
+        $count - $failures,
+        $count,
+      )
+    );
+  }
+}

--- a/class/src/CommandService.php
+++ b/class/src/CommandService.php
@@ -1,0 +1,33 @@
+<?php
+declare(strict_types=1);
+
+namespace PgBoard\PgBoard;
+
+use PgBoard\PgBoard\Command\DatabaseSeeder;
+use Symfony\Component\Console\Application;
+
+class CommandService
+{
+  private array $commands = [
+    DatabaseSeeder::class,
+  ];
+
+  public function __construct(
+    private readonly Application $application
+  ) {}
+
+  public static function load() {
+    $application = new Application();
+    $service = new self($application);
+    $service->load_commands();
+  }
+
+  public function load_commands()
+  {
+    foreach ($this->commands as $command_class) {
+      $this->application->add(new $command_class());
+    }
+
+    $this->application->run();
+  }
+}

--- a/class/src/CommandService.php
+++ b/class/src/CommandService.php
@@ -16,10 +16,12 @@ class CommandService
     private readonly Application $application
   ) {}
 
-  public static function load() {
+  public static function load(): Application {
     $application = new Application();
     $service = new self($application);
     $service->load_commands();
+
+    return $application;
   }
 
   public function load_commands()

--- a/composer.json
+++ b/composer.json
@@ -3,13 +3,16 @@
     "description": "A pretty good board.",
     "type": "project",
     "require-dev": {
+        "fakerphp/faker": "^1.23",
         "phpstan/phpstan": "^1.10",
         "phpunit/phpunit": "^10.3",
-        "fakerphp/faker": "^1.23",
         "symfony/console": "^6.3"
     },
     "autoload": {
-        "classmap": ["class/"]
+        "classmap": ["class/"],
+        "psr-4": {
+            "PgBoard\\PgBoard\\": "class/src"
+        }
     },
     "autoload-dev": {
         "psr-4": {
@@ -18,5 +21,8 @@
     },
     "require": {
         "symfony/dotenv": "^6.3"
+    },
+    "config": {
+        "sort-packages": true
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,8 @@
     "require-dev": {
         "phpstan/phpstan": "^1.10",
         "phpunit/phpunit": "^10.3",
-        "fakerphp/faker": "^1.23"
+        "fakerphp/faker": "^1.23",
+        "symfony/console": "^6.3"
     },
     "autoload": {
         "classmap": ["class/"]

--- a/composer.json
+++ b/composer.json
@@ -5,8 +5,7 @@
     "require-dev": {
         "phpstan/phpstan": "^1.10",
         "phpunit/phpunit": "^10.3",
-        "fakerphp/faker": "^1.23",
-        "symfony/console": "^6.3"
+        "fakerphp/faker": "^1.23"
     },
     "autoload": {
         "classmap": ["class/"]

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "d813a2453c0e5e9ca95bc32adcdd4e29",
+    "content-hash": "e13ba15dc53405792e9382c4e548bc66",
     "packages": [
         {
             "name": "symfony/dotenv",

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,7 @@ services:
     links:
       - postgres
   composer:
+    container_name: pgb-composer
     image: composer:latest
     volumes:
       - ./:/var/www/html

--- a/docker/php/Dockerfile
+++ b/docker/php/Dockerfile
@@ -1,5 +1,7 @@
 FROM php:8.2-fpm
 
+COPY --from=composer /usr/bin/composer /usr/bin/composer
+
 RUN apt-get -y update \
     && apt-get install -y build-essential git zip unzip autoconf postgresql libpq-dev less
 


### PR DESCRIPTION
This PR is a first pass at seeding the local board database with members, member messages, threads and replies, and chat posts. It's not a comprehensive database seeder, but should serve as a good starting point for standing up the local development environment.

The primary changes involve:
1. Installing [Symfony Console](https://symfony.com/doc/current/components/console.html) as a development dependency for seeding data.
2. Creating a `make` command to run the seeder non-interactively (it can still be run interactively to set amounts of data for each type).

The next step for development will be to automatically stand up the database during the Docker build process so that this seeder could be called manually to load the database with data without that manual setup step.