### PR TITLE
Fix incorrect indicator of read threads in mobile view.

### DIFF
--- a/css/core.css
+++ b/css/core.css
@@ -9,30 +9,79 @@
 @import "/css/mobile.css";
 
 /* Start Reset */
-* { margin: 0px; padding: 0px; }
-fieldset,img { border: none; outline: none; }
+* {
+    margin: 0px;
+    padding: 0px;
+}
 
-img { border: none; }
+fieldset, img {
+    border: none;
+    outline: none;
+}
+
+img {
+    border: none;
+}
+
 /* End Reset */
 
 /* Start Base Styles */
-body
-{
-  font-size: 62.5%;
-  height: 100%;
+body {
+    font-size: 62.5%;
+    height: 100%;
 }
 
-a:link, a:visited, a:active { text-decoration: none; }
-a:hover { text-decoration: underline; }
-.hide { display: none; }
-.clear { clear: both; }
-.blink { text-decoration: blink; }
-.link,.lurker a { text-decoration: underline !important; }
-img { cursor: pointer; max-width: 100%; }
-h1,h2,h3,h4,h5 { font-weight: bold; }
-h1 { font-size: 2.0em; }
-h2 { font-size: 1.8em; }
-h3 { font-size: 1.6em; }
-h4 { font-size: 1.4em; }
-h5 { font-size: 1.2em; }
+a:link, a:visited, a:active {
+    text-decoration: none;
+}
+
+a:hover {
+    text-decoration: underline;
+}
+
+.hide {
+    display: none;
+}
+
+.clear {
+    clear: both;
+}
+
+.blink {
+    text-decoration: blink;
+}
+
+.link, .lurker a {
+    text-decoration: underline !important;
+}
+
+img {
+    cursor: pointer;
+    max-width: 100%;
+}
+
+h1, h2, h3, h4, h5 {
+    font-weight: bold;
+}
+
+h1 {
+    font-size: 2.0em;
+}
+
+h2 {
+    font-size: 1.8em;
+}
+
+h3 {
+    font-size: 1.6em;
+}
+
+h4 {
+    font-size: 1.4em;
+}
+
+h5 {
+    font-size: 1.2em;
+}
+
 /* End Base Styles */

--- a/css/dropmenu.css
+++ b/css/dropmenu.css
@@ -1,33 +1,39 @@
-ul.drop
-{
-  list-style: none;
-  height: 1%;
-}
-.drop li
-{
-  float: left;
-  margin-right: 0.25em;
-  list-style: none;
-}
-a.domenu:hover { text-decoration: none; }
-
-.dropmenu .control { display: none; }
-.dropmenu:hover a, .dropmenu.active a, .hovermenu a
-{
-  padding: 0.2em;
-}
-.dropmenu:hover .control, .dropmenu.active .control, .hovermenu .control
-{
-  display: inline;
-  padding: 0.2em;
-  cursor: pointer;
+ul.drop {
+    height: 1%;
+    list-style: none;
 }
 
-.submenu
-{
-  list-style: none;
-	position: absolute;
-	width: 150px;
-  display: none;
+.drop li {
+    float: left;
+    list-style: none;
+    margin-right: 0.25em;
 }
-.submenu li { list-style: none; }
+
+a.domenu:hover {
+    text-decoration: none;
+}
+
+.dropmenu .control {
+    display: none;
+}
+
+.dropmenu:hover a, .dropmenu.active a, .hovermenu a {
+    padding: 0.2em;
+}
+
+.dropmenu:hover .control, .dropmenu.active .control, .hovermenu .control {
+    cursor: pointer;
+    display: inline;
+    padding: 0.2em;
+}
+
+.submenu {
+    display: none;
+    list-style: none;
+    position: absolute;
+    width: 150px;
+}
+
+.submenu li {
+    list-style: none;
+}

--- a/css/error.css
+++ b/css/error.css
@@ -1,31 +1,33 @@
-#error
-{
-  background-color: #000;
-  padding: .5em;
-  height: 500px;
-  overflow: auto;
-  color: #fff;
-  display: none;
-  font-size: 1.1em;
+#error {
+    background-color: #000;
+    color: #fff;
+    display: none;
+    font-size: 1.1em;
+    height: 500px;
+    overflow: auto;
+    padding: .5em;
 }
 
-#error pre { font-family: verdana; }
-
-#error hr
-{
-  margin-top: 5px;
-  padding-bottom: 5px;
-  height: 1px;
-  border: none;
-  border-top: 1px solid #333;
+#error pre {
+    font-family: verdana;
 }
 
-#errorbar
-{
-  background-color: #000;
-  text-align: right;
-  font-size: 11px;
-  color: #fff;
-  padding: 2px;
+#error hr {
+    border: none;
+    border-top: 1px solid #333;
+    height: 1px;
+    margin-top: 5px;
+    padding-bottom: 5px;
 }
-#errorbar a { color: #fff; }
+
+#errorbar {
+    background-color: #000;
+    color: #fff;
+    font-size: 11px;
+    padding: 2px;
+    text-align: right;
+}
+
+#errorbar a {
+    color: #fff;
+}

--- a/css/form.css
+++ b/css/form.css
@@ -1,73 +1,73 @@
-.coreform fieldset { margin-top: 10px; }
-
-.coreform legend
-{
-  padding: 0px 2px;
-	font-weight: bold;
-	_margin: 0px -7px;
-	font-size: 1.2em;
+.coreform fieldset {
+    margin-top: 10px;
 }
 
-.coreform label
-{
-  display: inline-block;
-	line-height: 1.8;
-	vertical-align: top;
+.coreform legend {
+    font-weight: bold;
+    padding: 0px 2px;
+    font-size: 1.2em;
 }
 
-.coreform fieldset ol
-{
-  margin: 0px;
-  padding: 0px;
+.coreform label {
+    display: inline-block;
+    line-height: 1.8;
+    vertical-align: top;
 }
 
-.coreform fieldset li
-{
-  list-style: none;
-	padding: 0px;
-	margin: 0px;
-	clear: left;
+.coreform fieldset ol {
+    margin: 0px;
+    padding: 0px;
 }
 
-.coreform fieldset fieldset
-{
-  border: none;
-	margin: 3px 0px 0px;
+.coreform fieldset li {
+    clear: left;
+    list-style: none;
+    margin: 0px;
+    padding: 0px;
 }
 
-.coreform fieldset fieldset legend
-{
-  padding: 0px 0px 5px;
-	font-weight: normal;
+.coreform fieldset fieldset {
+    border: none;
+    margin: 3px 0px 0px;
 }
 
-.coreform fieldset fieldset label
-{
-  display: block;
-  width: auto;
+.coreform fieldset fieldset legend {
+    font-weight: normal;
+    padding: 0px 0px 5px;
 }
 
-.coreform label
-{
-  width: 110px;
-  display: block;
-  float: left;
-  font-weight: bold;
-}
-.coreform fieldset fieldset label { margin-left: 113px; } /* Width plus 3 (html space) */
-
-.coreform fieldset li { padding: 5px 10px 0px 10px; }
-
-.coreform .submit { margin-left: 119px; }
-
-.alert
-{
-  text-decoration: underline;
-  cursor: pointer;
+.coreform fieldset fieldset label {
+    display: block;
+    width: auto;
 }
 
-.alertmsg
-{
-  float: right;
-  font-weight: bold;
+.coreform label {
+    display: block;
+    float: left;
+    font-weight: bold;
+    width: 110px;
+}
+
+.coreform fieldset fieldset label {
+    margin-left: 113px;
+}
+
+/* Width plus 3 (html space) */
+
+.coreform fieldset li {
+    padding: 5px 10px 0px 10px;
+}
+
+.coreform .submit {
+    margin-left: 119px;
+}
+
+.alert {
+    cursor: pointer;
+    text-decoration: underline;
+}
+
+.alertmsg {
+    float: right;
+    font-weight: bold;
 }

--- a/css/layout.css
+++ b/css/layout.css
@@ -1,123 +1,150 @@
 /* Start Container */
 #content,
 #header,
-#footer
-{
-  clear: both;
-  margin: 0px auto;
-  min-width: 650px;
-  max-width: 1400px;
-  width: 99%;
+#footer {
+    clear: both;
+    margin: 0px auto;
+    max-width: 1400px;
+    min-width: 650px;
+    width: 99%;
 }
+
 #content .pad,
 #header .pad,
-#footer .pad { padding: 10px; }
-.title { float: left; }
-.subtitle { float: left; clear: left; }
+#footer .pad {
+    padding: 10px;
+}
+
+.title {
+    float: left;
+}
+
+.subtitle {
+    float: left;
+    clear: left;
+}
+
 /* End Container */
 
 
 /* Start Login Box */
-#auth
-{
-  float: right;
-  text-align: right;
-  height: 50px;
-  margin-bottom: -50px;
+#auth {
+    float: right;
+    height: 50px;
+    margin-bottom: -50px;
+    text-align: right;
 }
-#auth ol { list-style: none; _float: right; }
-#auth li { float: left; }
-#auth label { font-weight: bold; margin-left: 5px; }
-#auth input
-{
-  border: 1px solid #000;;
-  padding: .15em;
-  width: 75px;
-  font-weight: bold;
-  font-size: 1em;
-  *padding: .2em;
+
+#auth ol {
+    list-style: none;
 }
-.loginbutton
-{
-  width: auto !important;
-  border: 1px solid #000 !important;
-  font-size: .9em !important;
-  *padding: 0em;
+
+#auth li {
+    float: left;
 }
+
+#auth label {
+    font-weight: bold;
+    margin-left: 5px;
+}
+
+#auth input {
+    border: 1px solid #000;;
+    font-size: 1em;
+    font-weight: bold;
+    padding: .15em;
+    width: 75px;
+}
+
+.loginbutton {
+    border: 1px solid #000 !important;
+    font-size: .9em !important;
+    width: auto !important;
+}
+
 /* End Login Box */
 
 
 /* Start Quick Search */
-#quicksearch
-{
-  float: right;
-  position: relative;
-  width: 30%;
-  height: 50px;
-
-}
-.searchwrap
-{
-  right: 0px;
-  padding: .2em .5em;
+#quicksearch {
+    float: right;
+    height: 50px;
+    position: relative;
+    width: 30%;
 }
 
-.searchtext
-{
-  position: relative;
-  border: 1px solid #000;
-  padding: .15em;
-  width: 15em;
-  font-weight: bold;
-  font-size: 1em;
-  *padding: .2em;
+.searchwrap {
+    padding: .2em .5em;
+    right: 0px;
 }
-.clearbutton
-{
-  border: 1px solid #000;
-  font-size: .9em !important;
-  *padding: 0em;
+
+.searchtext {
+    border: 1px solid #000;
+    position: relative;
+    padding: .15em;
+    font-weight: bold;
+    font-size: 1em;
+    padding: .2em;
+    width: 15em;
 }
+
+.clearbutton {
+    border: 1px solid #000;
+    font-size: .9em !important;
+}
+
 /* End Quick Search */
 
 
 /* Start Menus */
-.nav
-{
-  position: relative;
-  list-style: none;
-  height: 50px;
-  width: 70%;
-  _float: left;
+.nav {
+    height: 50px;
+    list-style: none;
+    position: relative;
+    width: 70%;
 }
-.setdown { position:absolute; bottom:0px; z-index: 1; }
-.nav li
-{
-  list-style: none;
-  margin-left: 5px;
-  float: left;
+
+.setdown {
+    bottom: 0px;
+    position: absolute;
+    z-index: 1;
 }
-.nav li a
-{
-  display: block;
-  padding: .33em 1em;  /* huge pain, do not touch */
+
+.nav li {
+    float: left;
+    list-style: none;
+    margin-left: 5px;
 }
-.shiftup { margin-top: -1px; }
-.hr
-{
-  line-height: 1px;
-  font-size: 1px;
-  height: 1px;
-  clear: both;
+
+.nav li a {
+    display: block;
+    padding: .33em 1em; /* huge pain, do not touch */
 }
-.hr hr { display: none; }
+
+.shiftup {
+    margin-top: -1px;
+}
+
+.hr {
+    clear: both;
+    font-size: 1px;
+    height: 1px;
+    line-height: 1px;
+}
+
+.hr hr {
+    display: none;
+}
+
 /* End Menu */
 
-.box
-{
-  padding: 1em;
+.box {
+    padding: 1em;
 }
 
 /* Start Footer */
-#version { text-align: right; }
+#version {
+    text-align: right;
+}
+
 /* End Footer */

--- a/css/list.css
+++ b/css/list.css
@@ -1,48 +1,69 @@
-.list
-{
-  list-style: none;
-  overflow: hidden;
-  clear: both;
-  width: 100%;
-  cursor: pointer;
+.list {
+    clear: both;
+    cursor: pointer;
+    list-style: none;
+    overflow: hidden;
+    width: 100%;
 }
-.read { margin-left: -3px; }
-.list li
-{
-  float: left;
-  padding: .23em 0em;
-}
-.list li span { display: none; }
-.list li span.dropmenu { display: inline; }
 
-.member { margin-left: .3em; width: 17%; }
-.subject
-{
-  padding-left: 40px;
-  width: 48.5%;
-  _width: 48%;
+.read {
+    margin-left: -3px;
 }
-.posts { width: 4%; margin-left: .5em; }
-.lastpost
-{
-  width: 28%;
-  text-align: right;
-  margin-right: .15em;
+
+.list li {
+    float: left;
+    padding: .23em 0em;
 }
-.extra
-{
-  float: left;
-  margin-left: -40px;
-  width: 40px;
-  _margin-left: 0px;
-  _height: 1.25em;
-  text-align: right;
+
+.list li span {
+    display: none;
 }
-.extra a { font-weight: bold; }
-.firstpost
-{
-  display: none;
-  padding: 2em;
+
+.list li span.dropmenu {
+    display: inline;
 }
-.even, .odd { clear: both; }
-#noresults { padding: 2em; }
+
+.member {
+    margin-left: .3em;
+    width: 17%;
+}
+
+.subject {
+    padding-left: 40px;
+    width: 48.5%;
+}
+
+.posts {
+    margin-left: .5em;
+    width: 4%;
+}
+
+.lastpost {
+    margin-right: .15em;
+    text-align: right;
+    width: 28%;
+}
+
+.extra {
+    float: left;
+    margin-left: -40px;
+    text-align: right;
+    width: 40px;
+}
+
+.extra a {
+    font-weight: bold;
+}
+
+.firstpost {
+    display: none;
+    padding: 2em;
+}
+
+.even, .odd {
+    clear: both;
+}
+
+#noresults {
+    padding: 2em;
+}

--- a/css/member.css
+++ b/css/member.css
@@ -1,24 +1,23 @@
-.nophoto
-{
-  width: 320px;
-  height: 240px;
+.nophoto {
+    height: 240px;
+    width: 320px;
 }
 
-.pref
-{
-  float: left;
-  width: 100px;
-  font-weight: bold;
-}
-.prefdata
-{
-  float: left;
+.pref {
+    float: left;
+    font-weight: bold;
+    width: 100px;
 }
 
-.memberinfo { list-style: none; }
+.prefdata {
+    float: left;
+}
 
-.memberinfo li
-{
-  clear: left;
-  padding-top: .5em;
+.memberinfo {
+    list-style: none;
+}
+
+.memberinfo li {
+    clear: left;
+    padding-top: .5em;
 }

--- a/css/mobile.css
+++ b/css/mobile.css
@@ -1,155 +1,222 @@
-@media only screen and (max-width: 1150px){
-	#quicksearch { display:none; }
+@media only screen and (max-width: 1150px) {
+    #quicksearch {
+        display: none;
+    }
 
-	.nav { 
-		width: 100%; 
-		overflow: auto; 
-		-webkit-overflow-scrolling: touch; 
-	}
-	.setdown { 
-		display: inline-flex;
-	}
-	.nav.bottom { 
-		display: inline-flex; 
-		overflow: auto; 
-		-webkit-overflow-scrolling: touch; 
-	}
-	.nav li { white-space: nowrap; }
-	.nav li a {
-	    padding: 1em 1em;
-	}
-	input[type="button"], input[type="submit"], input[type="reset"], input {
-	    padding: 0.5em 0.5em;
-	}
-	.subject { width: 47%; }
-	.box {
-		overflow:auto;
-	}
-	.view { overflow: auto; }
-	.nav.top { min-height: 80px; }
+    .nav {
+        -webkit-overflow-scrolling: touch;
+        overflow: auto;
+        width: 100%;
+    }
 
+    .setdown {
+        display: inline-flex;
+    }
+
+    .nav.bottom {
+        -webkit-overflow-scrolling: touch;
+        display: inline-flex;
+        overflow: auto;
+    }
+
+    .nav li {
+        white-space: nowrap;
+    }
+
+    .nav li a {
+        padding: 1em 1em;
+    }
+
+    input[type="button"], input[type="submit"], input[type="reset"], input {
+        padding: 0.5em 0.5em;
+    }
+
+    .subject {
+        width: 47%;
+    }
+
+    .box {
+        overflow: auto;
+    }
+
+    .view {
+        overflow: auto;
+    }
+
+    .nav.top {
+        min-height: 80px;
+    }
 }
 
-@media only screen and (max-width: 930px){
+@media only screen and (max-width: 930px) {
+    html body {
+        margin: 0;
+        padding: 0px 0px;
+    }
 
-	html body {
-		margin: 0;
-		padding: 0px 0px;
-	}
+    #content {
+        display: block;
+        min-width: 320px !important;
+        width: 100% !important;
+    }
 
-	#content {
-		display: block;
-		width: 100% !important;
-		min-width: 320px !important;
-	}
+    #content .pad {
+        margin: 0;
+        padding: 0;
+    }
 
-	#content .pad {
-		margin: 0;
-		padding: 0;
-	}
-	.subtitle {
-		width: 85%;
-	}
-	#auth {
-		height: auto;
-		padding-top: 10px;
-		margin-bottom: 0;
-	}
-	.subject {
-		width: 65%;
-		font-weight:normal;
-	}
+    .subtitle {
+        width: 85%;
+    }
 
-	.member {
-		width: 20%;
-		text-overflow: ellipsis;
-		overflow: hidden;
-		white-space: nowrap;
-	}
-	.posts {
-		float: right!important;
-		width: 40px;
-	}
-		
-	.pref { float:none; }	
-	body ul.list.read { border-left: 0; border-right: 0; margin-left: 0; }
-	body ul.list { border-left: 5px solid red; border-right:none; margin-left:0px }
-	.even, .odd {
-		overflow: hidden;
-	}
-	
-	.list li {
-		padding: .4em 0;
-	}
+    #auth {
+        height: auto;
+        margin-bottom: 0;
+        padding-top: 10px;
+    }
 
+    .subject {
+        font-weight: normal;
+        width: 65%;
+    }
 
-	.extra { 
-		margin-left: 0px;
-		width: initial;
-	}
-	.extra a { font-weight: 400; }
-	.list .lastpost { color: #000; display:none; }
+    .member {
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+        width: 20%;
+    }
 
-	.bottom li {  border: 0; font-weight:normal; }
+    .posts {
+        float: right !important;
+        width: 40px;
+    }
 
-	textarea { width: 100% !important; font-size:140%;}
-	input[type=text], #m { width: 100% !important; }
-	.coreform .submit { margin-left: 10px; }
-	.firstpost { padding: .4em .4em 1em .4em; }
-	.postbody a { text-decoration:underline; !important; }
-	.view .odd { padding-top: 1.0em; }
-	
-	.title, .subtitle, .subtitle a {
-		opacity: 0.8;
-	}	
+    .pref {
+        float: none;
+    }
+
+    body ul.list.read {
+        border-left: 0;
+        border-right: 0;
+        margin-left: 0;
+    }
+
+    body ul.list {
+        border-left: 5px solid red;
+        border-right: none;
+        margin-left: 0px
+    }
+
+    .even, .odd {
+        overflow: hidden;
+    }
+
+    .list li {
+        padding: .4em 0;
+    }
+
+    .extra {
+        margin-left: 0px;
+        width: initial;
+    }
+
+    .extra a {
+        font-weight: 400;
+    }
+
+    .list .lastpost {
+        color: #000;
+        display: none;
+    }
+
+    .bottom li {
+        border: 0;
+        font-weight: normal;
+    }
+
+    textarea {
+        font-size: 140%;
+        width: 100% !important;
+    }
+
+    input[type=text], #m {
+        width: 100% !important;
+    }
+
+    .coreform .submit {
+        margin-left: 10px;
+    }
+
+    .firstpost {
+        padding: .4em .4em 1em .4em;
+    }
+
+    .postbody a {
+        text-decoration: underline !important;
+    }
+
+    .view .odd {
+        padding-top: 1.0em;
+    }
+
+    .title, .subtitle, .subtitle a {
+        opacity: 0.8;
+    }
 }
 
-@media only screen and (max-width: 850px){
-	.view li { margin:0px; }
+@media only screen and (max-width: 850px) {
+    .view li {
+        margin: 0px;
+    }
 }
 
 @media only screen and (max-width: 586px) {
+    .nav.top li {
+        margin-left: 0;
+        margin-right: 4px;
+    }
 
-	.nav.top li {
-		margin-left: 0;
-		margin-right: 4px;
-		}
-		
-	.nav.top li a {
-		padding: 1em .39em!important;
-	}
-		
-	.top .setdown li {
-		border: 0;
-		font-weight: bold;
-		}
-		
-	.nav .setdown li:hover, .nav .setdown a:hover {
-		text-decoration: none;
-		}
-		
-	.top .setdown li a {
-			text-decoration: none;
-		}
+    .nav.top li a {
+        padding: 1em .39em !important;
+    }
 
-	#content > div > div.small.clear {
-		margin-top: 20px;
-	}
+    .top .setdown li {
+        border: 0;
+        font-weight: bold;
+    }
 
-	.subject {
-		width: 61%;
-	}
-	.nav.top { min-height: 69px; }
+    .nav .setdown li:hover, .nav .setdown a:hover {
+        text-decoration: none;
+    }
+
+    .top .setdown li a {
+        text-decoration: none;
+    }
+
+    #content > div > div.small.clear {
+        margin-top: 20px;
+    }
+
+    .subject {
+        width: 61%;
+    }
+
+    .nav.top {
+        min-height: 69px;
+    }
 }
 
 @media only screen and (max-width: 380px) {
-	#auth {
-		margin-bottom: 0px;
-	}
-	.posts {
-		width: 47px;
-	}
-	.subject {
-		width: 58%;
-	}
+    #auth {
+        margin-bottom: 0px;
+    }
+
+    .posts {
+        width: 47px;
+    }
+
+    .subject {
+        width: 58%;
+    }
 }

--- a/css/mobile.css
+++ b/css/mobile.css
@@ -101,7 +101,7 @@
         margin-left: 0;
     }
 
-    body ul.list:not(.read) {
+    body ul.list {
         border-left: 5px solid inherit;
         border-right: none;
         margin-left: 0px

--- a/css/mobile.css
+++ b/css/mobile.css
@@ -96,14 +96,13 @@
         float: none;
     }
 
-    body ul.list.read {
-        border-left: 0;
+    .read {
         border-right: 0;
         margin-left: 0;
     }
 
-    body ul.list {
-        border-left: 5px solid red;
+    body ul.list:not(.read) {
+        border-left: 5px solid inherit;
         border-right: none;
         margin-left: 0px
     }

--- a/css/view.css
+++ b/css/view.css
@@ -1,31 +1,47 @@
-.view
-{
-  list-style: none;
-  clear: both;
+.view {
+    clear: both;
+    list-style: none;
 }
-.view li
-{
-  list-style: none;
-  padding: .23em .35em;
-}
-.view .even a.memberlink { font-weight: bold; }
-.view .odd { padding-bottom: 1.25em;}
-.list li span { display: none; }
 
-.view li, .firstpost { margin-bottom: 1px; }
-
-.view pre
-{
-  font-family: monospace;
-  font-size: 1.2em;
-  float: left;
-  padding: 1em;
-  margin: 1em;
+.view li {
+    list-style: none;
+    padding: .23em .35em;
 }
-.postinfo, .controls { float: left; }
-.count { text-align: right; float: right; }
-.collapse
-{
-  padding: 10px;
-  margin-bottom: 1px;
+
+.view .even a.memberlink {
+    font-weight: bold;
+}
+
+.view .odd {
+    padding-bottom: 1.25em;
+}
+
+.list li span {
+    display: none;
+}
+
+.view li, .firstpost {
+    margin-bottom: 1px;
+}
+
+.view pre {
+    float: left;
+    font-family: monospace;
+    font-size: 1.2em;
+    margin: 1em;
+    padding: 1em;
+}
+
+.postinfo, .controls {
+    float: left;
+}
+
+.count {
+    float: right;
+    text-align: right;
+}
+
+.collapse {
+    margin-bottom: 1px;
+    padding: 10px;
 }


### PR DESCRIPTION
When viewing the board on a mobile device, the indicator in the sidebar that informs users whether they've already read the thread or not was reversed from the display on non-mobile devices. This PR corrects that issue, and also uniformly formats the stylesheets and alphabetizes selector properties.