### PR TITLE
Show both first and latest post in thread preview

### DIFF
--- a/lang/en.default.php
+++ b/lang/en.default.php
@@ -7,6 +7,8 @@ define("SPACE"," ");
 define("NON_BREAKING_SPACE","&nbsp;");
 define("STICKY_TEXT","<strong>Sticky:</strong>");
 define("ARROW_RIGHT","&raquo;"); // if changed must fix core.js to match
+define("FIRST_POST","First post:");
+define("LATEST_POST","Latest post:");
 define("ARROW_LEFT","&laquo;");  // if changed must fix core.js to match
 define("ERROR_MEMBER_NAME","Your name must be between 3 and 15 characters.  Letters, numbers, underscores and hypens are allowed.");
 define("ERROR_MEMBER_NAME_INUSE","That name is already in use.");

--- a/module/thread/get.php
+++ b/module/thread/get.php
@@ -153,10 +153,28 @@ function view_get()
 
 function firstpost_get()
 {
-  global $DB,$Parse;
+  global $DB,$Parse,$Core;
   if(!id()) return;
-  $body = $DB->value("SELECT body FROM thread_post WHERE thread_id=$1 ORDER BY date_posted LIMIT 1",array(id()));
-  print $Parse->run($body);
+  $DB->query("SELECT tp.id, tp.body, tp.date_posted, m.name FROM thread_post tp LEFT JOIN member m ON m.id=tp.member_id WHERE tp.thread_id=$1 ORDER BY tp.date_posted LIMIT 1",array(id()));
+  $first = $DB->load_array();
+  $DB->query("SELECT tp.id, tp.body, tp.date_posted, m.name FROM thread_post tp LEFT JOIN member m ON m.id=tp.member_id WHERE tp.thread_id=$1 ORDER BY tp.date_posted DESC LIMIT 1",array(id()));
+  $latest = $DB->load_array();
+  _firstpost_render($first, FIRST_POST, $Parse, $Core);
+  if($first['id'] !== $latest['id'])
+  {
+    print "<br />\n";
+    _firstpost_render($latest, LATEST_POST, $Parse, $Core);
+  }
+}
+
+function _firstpost_render($post, $label, $Parse, $Core)
+{
+  $date = date(VIEW_DATE_FORMAT, strtotime($post['date_posted']));
+  $name = $Core->member_link($post['name']);
+  print "<ul class=\"view\">\n";
+  print "  <li class=\"info even\"><div class=\"postinfo\"><strong>$label</strong> $name posted this on $date</div><div class=\"clear\"></div></li>\n";
+  print "  <li class=\"postbody odd\">".$Parse->run($post['body'])."</li>\n";
+  print "</ul>\n";
 }
 
 function viewpost_get()


### PR DESCRIPTION
- Clicking the » chevron in the thread list now shows both the first post and the most recent post, each rendered with author name, timestamp, and body (matching the thread view style)
- Single-post threads only show the first post (no duplicate)
- Added `FIRST_POST` and `LATEST_POST` language constants